### PR TITLE
Improve warm-up visibility and accelerate MetaNetX startup

### DIFF
--- a/MCC/Balancing/MCC.py
+++ b/MCC/Balancing/MCC.py
@@ -7,7 +7,7 @@ from ..ModelInterface.ModelInterface import ModelInterface
 from .satCore import SatCore
 from .formulaOptimizer import FormulaOptimizer
 from .adherenceOptimizer import AdherenceOptimizer
-from ..DataCollection.DataCollection import DataCollector
+from ..DataCollection.DataCollection import DataCollector, default_data_path
 from ..util import  adjust_proton_count
 import logging
 import time
@@ -33,12 +33,14 @@ class MassChargeCuration:
         cache_ids (list): List of ids to cache.
 
     """
-    def __init__(self, model, data_collector = None, data_path = "./data", fixed_assignments = None, fixed_reactions = None, run_optimization = True, cache_ids = None, **kw):
+    def __init__(self, model, data_collector = None, data_path = None, fixed_assignments = None, fixed_reactions = None, run_optimization = True, cache_ids = None, **kw):
         total_time = time.process_time()
         logging.info(f"Setting up model system.")
         self.model_interface = ModelInterface(model)
         self.pseudo_reactions = self.model_interface.get_pseudo_reactions()
         self.original_model_interface = self.model_interface.copy()
+        if data_path is None:
+            data_path = default_data_path()
         logging.info(f"Collecting Data...")
         t = time.process_time()
         self.data_collector = DataCollector(model, data_path, cache_ids = cache_ids, **kw) if data_collector is None else data_collector

--- a/MCC/Balancing/MCC.py
+++ b/MCC/Balancing/MCC.py
@@ -82,6 +82,23 @@ class MassChargeCuration:
         self.adjust_protons()
         self.total_time = time.process_time() - total_time
 
+    @classmethod
+    def warm_up(cls, data_path = None, used_annotations = None, no_local = False, biocyc_path = None):
+        """
+        Preloads and caches the configured external database artifacts.
+
+        This can be used before running curation so first-use downloads and local consolidation
+        happen in a dedicated warm-up step.
+        """
+        if data_path is None:
+            data_path = default_data_path()
+        return DataCollector.warm_up(
+            data_path = data_path,
+            used_annotations = used_annotations,
+            no_local = no_local,
+            biocyc_path = biocyc_path,
+        )
+
     def reintroduce_wildcards(self):
         # get any unknown metabolites
         wildcard_metabolites = set()

--- a/MCC/DataCollection/DataCollection.py
+++ b/MCC/DataCollection/DataCollection.py
@@ -14,11 +14,12 @@ from .Requests.MetaNetX import MetaNetXInterface
 from .Requests.ModelSEED import ModelSEEDInterface
 
 
-default_interfaces = {"metanetx.chemical" : MetaNetXInterface,
-                    "bigg.metabolite" : BiGGInterface,
-                    "seed.compound" : ModelSEEDInterface,
-                    "biocyc" : BioCycInterface
-                    }
+default_interfaces = {
+    "metanetx.chemical": MetaNetXInterface,
+    "bigg.metabolite": BiGGInterface,
+    "seed.compound": ModelSEEDInterface,
+    "biocyc": BioCycInterface,
+}
 
 
 def default_data_path():
@@ -36,7 +37,7 @@ def default_data_path():
 class DataCollector:
     """
     Class intended to be used by the ModelBalancer to gather the information for the metabolites from different databases.
-    Uses further specified interfaces to different databases to gather the data, cleans the gathered formulae and provides a function to 
+    Uses further specified interfaces to different databases to gather the data, cleans the gathered formulae and provides a function to
     gather the ids for different databases for the metabolites based on the present information.
 
     The class can be used with online and offline resources, however, full functionality is only given if both can be used.
@@ -45,7 +46,7 @@ class DataCollector:
         model (cobrapy.Model): Model for which the DataCollector will gather the information and takes information to gather ids.
         data_path (string): Optional; Path where offline data is searched for/downloaded to.
         update_ids (bool): Optional; Whether or not to gather/update the database identifiers for the used databases.
-        gather_information (bool): Optional; If False, will not actually gather any information. Useful if you like 
+        gather_information (bool): Optional; If False, will not actually gather any information. Useful if you like
             to register other interfaces first, or only want to update ids.
         used_annotations ([str]): Optional; Annotations to use, defaults to all. If you distrust a certain database or only want to use a specific one
             you can specify which databases to use here.
@@ -54,26 +55,56 @@ class DataCollector:
         cache_ids (str): Optional; Name of cache file for the metabolite ids in the data_path. If given, will load the ids from the cache file instead of updating them.
     """
 
-    def __init__(self, model = None, data_path = None, update_ids = False, gather_information = True, used_annotations = None, no_local = False, biocyc_path = None, cache_ids = None):
+    def __init__(
+        self,
+        model=None,
+        data_path=None,
+        update_ids=False,
+        gather_information=True,
+        used_annotations=None,
+        no_local=False,
+        biocyc_path=None,
+        cache_ids=None,
+    ):
+        is_warm_up_mode = (
+            (model is None) and (not update_ids) and (not gather_information)
+        )
         if model is None:
-            logging.warning(f"No model was passed to DataCollector. This is most likely not intended.")
+            if is_warm_up_mode:
+                logging.info(
+                    "Initializing DataCollector in warm-up mode without a model."
+                )
+            else:
+                logging.warning(
+                    "No model was passed to DataCollector. This is most likely not intended."
+                )
         else:
             self.model_interface = ModelInterface(model)
         self.no_local = no_local
         self.interfaces = {}
-        self.used_annotations = list(default_interfaces.keys()) if used_annotations is None else used_annotations
+        self.used_annotations = (
+            list(default_interfaces.keys())
+            if used_annotations is None
+            else used_annotations
+        )
         self.data_path = default_data_path() if data_path is None else data_path
         self.strict_linkback = True
-        try:
-            os.makedirs(self.data_path)
-        except OSError:
-            pass
+        cache_dir_exists = os.path.isdir(self.data_path)
+        os.makedirs(self.data_path, exist_ok=True)
+        if cache_dir_exists:
+            logging.info(f"Using existing cache directory: {self.data_path}")
+        else:
+            logging.info(f"Created cache directory: {self.data_path}")
+        logging.info(f"Configured interfaces: {self.used_annotations}")
+        logging.info(f"Local cache usage enabled: {not self.no_local}")
         self._load_default_interfaces(self.data_path, biocyc_path)
         self.assignments = {}
         self.allow_undefined_charge = True
         if update_ids:
             if cache_ids:
-                raise NotImplementedError("Caching of ids is currently not implemented.")
+                raise NotImplementedError(
+                    "Caching of ids is currently not implemented."
+                )
                 cache_path = os.path.join(self.data_path, cache_ids)
                 if os.path.exists(cache_path):
                     with open(cache_path, "rb") as f:
@@ -88,7 +119,65 @@ class DataCollector:
         if gather_information:
             self.gather_info()
 
-    def _load_default_interfaces(self, data_path, biocyc_path = None):
+    @classmethod
+    def warm_up(
+        cls, data_path=None, used_annotations=None, no_local=False, biocyc_path=None
+    ):
+        """
+        Preloads and caches the configured external database artifacts without requiring a model.
+
+        Args:
+            data_path (str): Optional cache directory for downloaded database artifacts.
+            used_annotations ([str]): Optional subset of database interfaces to preload.
+            no_local (bool): If True, skips local artifact download/consolidation.
+            biocyc_path (str): Optional BioCyc base path for consolidating BioCyc into the local cache.
+
+        Returns:
+            DataCollector configured with the requested interfaces and warmed caches.
+        """
+        cls._configure_warm_up_logging()
+        if data_path is None:
+            data_path = default_data_path()
+        warm_up_start = time.perf_counter()
+        logging.info(f"Starting cache warm-up in {data_path}")
+        logging.info(
+            f"Requested interfaces: {used_annotations if not (used_annotations is None) else 'all default interfaces'}"
+        )
+        logging.info(f"Using local cache artifacts: {not no_local}")
+        if biocyc_path is None:
+            logging.info(
+                "BioCyc base path: not provided (using cached BioCyc if available)."
+            )
+        else:
+            logging.info(f"BioCyc base path: {biocyc_path}")
+        collector = cls(
+            model=None,
+            data_path=data_path,
+            update_ids=False,
+            gather_information=False,
+            used_annotations=used_annotations,
+            no_local=no_local,
+            biocyc_path=biocyc_path,
+            cache_ids=None,
+        )
+        logging.info(
+            f"[{time.perf_counter() - warm_up_start:.3f} s] Finished warming external database caches."
+        )
+        return collector
+
+    @classmethod
+    def _configure_warm_up_logging(cls):
+        root_logger = logging.getLogger()
+        if not root_logger.handlers:
+            logging.basicConfig(
+                format="%(levelname)s: %(filename)s %(lineno)d, %(funcName)s: %(message)s",
+                level=logging.INFO,
+            )
+            logging.info(
+                "No logging handlers detected. Enabled INFO logging for warm-up progress."
+            )
+
+    def _load_default_interfaces(self, data_path, biocyc_path=None):
         """
         Function to load all the default interfaces, specified in default_interfaces at the top of the file.
         Currently compromised of BiGG, MetaNetX, BioCyc and ModelSEED.
@@ -97,15 +186,41 @@ class DataCollector:
             data_path: Path for the offline database files.
             biocyc_path: Optional; Path for the BioCyc offline database file.
         """
-        for identifier, constructor in default_interfaces.items():
-            if not (self.used_annotations is None or (identifier in self.used_annotations)): continue
-            if identifier == "biocyc":
-                if not (biocyc_path is None):
-                    interface = constructor(data_path, no_local = self.no_local, biocyc_base_path = biocyc_path)
-            else:
-                interface = constructor(data_path, no_local = self.no_local)
-            self.register_interface(identifier, interface)
+        unknown_annotations = sorted(
+            set(self.used_annotations).difference(default_interfaces.keys())
+        )
+        if len(unknown_annotations) > 0:
+            logging.warning(
+                f"Unknown annotations requested and ignored: {unknown_annotations}"
+            )
 
+        selected_identifiers = [
+            identifier
+            for identifier in default_interfaces.keys()
+            if self.used_annotations is None or identifier in self.used_annotations
+        ]
+        logging.info(
+            f"Loading {len(selected_identifiers)} data interfaces: {selected_identifiers}"
+        )
+
+        for identifier in selected_identifiers:
+            constructor = default_interfaces[identifier]
+            load_start = time.perf_counter()
+            logging.info(f"Loading data interface '{identifier}'...")
+            try:
+                if identifier == "biocyc":
+                    interface = constructor(
+                        data_path, no_local=self.no_local, biocyc_base_path=biocyc_path
+                    )
+                else:
+                    interface = constructor(data_path, no_local=self.no_local)
+            except Exception:
+                logging.exception(f"Failed loading data interface '{identifier}'.")
+                raise
+            self.register_interface(identifier, interface)
+            logging.info(
+                f"[{time.perf_counter() - load_start:.3f} s] Loaded data interface '{identifier}'."
+            )
 
     def register_interface(self, identifier, interface):
         """
@@ -117,9 +232,7 @@ class DataCollector:
         """
         self.interfaces[identifier] = interface
 
-    
-
-    def get_formulae(self, metabolite : Metabolite):
+    def get_formulae(self, metabolite: Metabolite):
         """
         Function to gather all available formulae/charges with the given interfaces.
 
@@ -137,68 +250,97 @@ class DataCollector:
             ids = annotations.get(db_id, [])
             for identifier in ids:
                 try:
-                    if not ((cur_assignments := interface.get_assignments_by_id(identifier)) is None):
+                    if not (
+                        (cur_assignments := interface.get_assignments_by_id(identifier))
+                        is None
+                    ):
                         logging.debug(f"{db_id}, {identifier}")
                         for assignment in cur_assignments:
-                            if assignment is None: continue
-                            if (type(assignment[0]) == float) or (assignment[0] is None): continue
-                            if (type(assignment[1]) ==float) and np.isnan(assignment[1]) or (assignment[1] is None):
+                            if assignment is None:
+                                continue
+                            if (type(assignment[0]) == float) or (
+                                assignment[0] is None
+                            ):
+                                continue
+                            if (
+                                (type(assignment[1]) == float)
+                                and np.isnan(assignment[1])
+                                or (assignment[1] is None)
+                            ):
                                 if self.allow_undefined_charge:
                                     assignment = (Formula(assignment[0]), None)
                                 else:
                                     continue
-                            assignment = (Formula(assignment[0]), int(assignment[1]) if not assignment[1] is None else None)
+                            assignment = (
+                                Formula(assignment[0]),
+                                int(assignment[1])
+                                if not assignment[1] is None
+                                else None,
+                            )
                             cur_db = assignments.get(assignment, set())
                             cur_db.add((db_id, identifier))
                             assignments[assignment] = cur_db
                 except KeyboardInterrupt:
                     raise
                 except Exception as e:
-                    logging.exception(f"Error getting formula for {identifier} in {db_id}:")
-
+                    logging.exception(
+                        f"Error getting formula for {identifier} in {db_id}:"
+                    )
 
         return assignments
-
 
     def gather_info(self):
         """
         Gathers formulae and charges for all metabolites in self.model.
         """
-        for i, metabolite in tqdm(enumerate(self.model_interface.metabolites.values()), total = len(self.model_interface.metabolites), desc = "Gathering information for metabolites"):
-            logging.debug(f"{i + 1}/{len(self.model_interface.metabolites)}: Getting information for {metabolite.id}")
+        for i, metabolite in tqdm(
+            enumerate(self.model_interface.metabolites.values()),
+            total=len(self.model_interface.metabolites),
+            desc="Gathering information for metabolites",
+        ):
+            logging.debug(
+                f"{i + 1}/{len(self.model_interface.metabolites)}: Getting information for {metabolite.id}"
+            )
             self.assignments[metabolite.id] = self.get_formulae(metabolite)
 
-    def get_assignments(self, metabolite : Metabolite, clean = True, partial = True, database_seperated = False):
+    def get_assignments(
+        self, metabolite: Metabolite, clean=True, partial=True, database_seperated=False
+    ):
         """
         Function to return all assignments for the given metabolite that were found using all registered interfaces.
-        
+
         Args:
             metabolite (cobrapy.Metabolite): Metabolite for which to gather information.
             clean (bool): Whether or not to also return formulae which were not cleaned (False currently not implemented).
             partial (bool): Whether or not to return formulae containing wildcard symbols (False currently not implemented).
             database_seperated (bool): Whether or not to return formulae mapping to the databases that contain them.
-        
+
         Returns:
             If database_seperated = False: Set of formula/charge combinations that could be found for this metabolite.
             Otherwise: Dictionary mapping (formula, charge) to set of database identifiers where it could be found.
 
         """
         if len(self.assignments) == 0:
-            logging.warn("Tried to get assignments with no gathered information. Try calling gather_info before.")
+            logging.warn(
+                "Tried to get assignments with no gathered information. Try calling gather_info before."
+            )
             return None
         assignments = self.assignments.get(metabolite.id, {})
         if metabolite.notes.get("type", "metabolite") != "class":
-            filtered_assignments = {assignment: databases for assignment, databases in assignments.items() if not ("R" in assignment[0])} 
+            filtered_assignments = {
+                assignment: databases
+                for assignment, databases in assignments.items()
+                if not ("R" in assignment[0])
+            }
             if len(filtered_assignments) > 0:
                 assignments = filtered_assignments
         if (clean == False) or (partial == False):
             raise NotImplementedError
-        
+
         if database_seperated:
             return assignments
         else:
             return set(assignments.keys())
-            
 
     def get_all_ids(self):
         """
@@ -206,21 +348,28 @@ class DataCollector:
         """
         now = time.process_time()
         total_new_ids = 0
-        for i, metabolite in tqdm(enumerate(self.model_interface.metabolites.values()), total = len(self.model_interface.metabolites), desc = "Gathering ids for metabolites"):
+        for i, metabolite in tqdm(
+            enumerate(self.model_interface.metabolites.values()),
+            total=len(self.model_interface.metabolites),
+            desc="Gathering ids for metabolites",
+        ):
             ids = self.get_ids(metabolite)
             total_new_ids += ids[2]
             logging.debug(f"Ids were {ids}")
             annotations = metabolite.cv_terms
-            for db in self.used_annotations: 
+            for db in self.used_annotations:
                 if db == "biocyc":
                     annotations[db] = [f"META:{entry}" for entry in ids[0][db]["ids"]]
                 else:
                     annotations[db] = list(ids[0][db]["ids"])
-            logging.debug(f"Updated metabolite {metabolite.id} annotations to {annotations}")
-        logging.info(f"[{time.process_time() - now:.3f} s] Gathered Ids. {total_new_ids} new ids found.")
+            logging.debug(
+                f"Updated metabolite {metabolite.id} annotations to {annotations}"
+            )
+        logging.info(
+            f"[{time.process_time() - now:.3f} s] Gathered Ids. {total_new_ids} new ids found."
+        )
 
-
-    def get_ids(self, metabolite : Metabolite):
+    def get_ids(self, metabolite: Metabolite):
         """
         Updates/gathers all ids for the given metabolite in the currently registered database interfaces.
 
@@ -232,8 +381,15 @@ class DataCollector:
                 => {db_identifer : {"old_ids" : [outdated ids], "ids" : set(current ids)}}
         """
 
-        names = [metabolite.name] if metabolite.name else ([metabolite.id[2:], metabolite.id] if metabolite.id else [])
-        DB_ids = {db_identifier : {"old_ids": [], "ids" : set()} for db_identifier in self.used_annotations}
+        names = (
+            [metabolite.name]
+            if metabolite.name
+            else ([metabolite.id[2:], metabolite.id] if metabolite.id else [])
+        )
+        DB_ids = {
+            db_identifier: {"old_ids": [], "ids": set()}
+            for db_identifier in self.used_annotations
+        }
         missing_links = set(self.used_annotations)
         check_list = set()
         # taking ids from annotations
@@ -241,32 +397,66 @@ class DataCollector:
         for db_identifier in annotations:
             if db_identifier in self.used_annotations:
                 if type(annotations[db_identifier]) is list:
-                    DB_ids[db_identifier]["ids"].update([meta_id.replace("META:", "") for meta_id in annotations[db_identifier]])
+                    DB_ids[db_identifier]["ids"].update(
+                        [
+                            meta_id.replace("META:", "")
+                            for meta_id in annotations[db_identifier]
+                        ]
+                    )
                 else:
-                    DB_ids[db_identifier]["ids"].add(annotations[db_identifier].replace("META:", ""))
-                check_list.update([(db_identifier, meta_id.replace("META:", "")) for meta_id in DB_ids[db_identifier]["ids"]])
+                    DB_ids[db_identifier]["ids"].add(
+                        annotations[db_identifier].replace("META:", "")
+                    )
+                check_list.update(
+                    [
+                        (db_identifier, meta_id.replace("META:", ""))
+                        for meta_id in DB_ids[db_identifier]["ids"]
+                    ]
+                )
                 missing_links.remove(db_identifier)
-        
+
         # fetching missing ids from other information
         new_ids_found = 0
         for db_identifier in missing_links:
             try:
-                if (not (found := self.interfaces[db_identifier].search_identifier(names, DB_ids)) is None) and (len(found) > 0):
+                if (
+                    not (
+                        found := self.interfaces[db_identifier].search_identifier(
+                            names, DB_ids
+                        )
+                    )
+                    is None
+                ) and (len(found) > 0):
                     DB_ids[db_identifier]["ids"].update(found)
                     new_ids_found += len(found)
-                    logging.debug(f"Found new ids {found} in {db_identifier} via id & name based search for {metabolite.id}")
-                    check_list.update([(db_identifier, meta_id.replace("META:", "")) for meta_id in DB_ids[db_identifier]["ids"]])
+                    logging.debug(
+                        f"Found new ids {found} in {db_identifier} via id & name based search for {metabolite.id}"
+                    )
+                    check_list.update(
+                        [
+                            (db_identifier, meta_id.replace("META:", ""))
+                            for meta_id in DB_ids[db_identifier]["ids"]
+                        ]
+                    )
             except KeyboardInterrupt:
                 raise
             except Exception as e:
                 logging.exception(f"Error searching for identifier in {db_identifier}:")
 
-        #update identifiers
-        flattened_ids = [meta_id.replace("META:", "") for meta_ids in DB_ids.values() for meta_id in meta_ids["ids"]]
+        # update identifiers
+        flattened_ids = [
+            meta_id.replace("META:", "")
+            for meta_ids in DB_ids.values()
+            for meta_id in meta_ids["ids"]
+        ]
         for db_identifier in self.interfaces:
             try:
-                old, new = self.interfaces[db_identifier].update_ids(flattened_ids, names)
-                check_list.difference_update([(db_identifier, meta_id) for meta_id in old])
+                old, new = self.interfaces[db_identifier].update_ids(
+                    flattened_ids, names
+                )
+                check_list.difference_update(
+                    [(db_identifier, meta_id) for meta_id in old]
+                )
                 DB_ids[db_identifier]["ids"].difference_update(old)
                 check_list.update([(db_identifier, meta_id) for meta_id in new])
                 DB_ids[db_identifier]["ids"].update(new)
@@ -279,10 +469,14 @@ class DataCollector:
         while len(check_list) > 0:
             next_id = check_list.pop()
             try:
-                result = self.interfaces[next_id[0]].get_other_references(next_id[1], self.used_annotations)
-                if result is None: continue
+                result = self.interfaces[next_id[0]].get_other_references(
+                    next_id[1], self.used_annotations
+                )
+                if result is None:
+                    continue
                 for database_id, meta_ids in result.items():
-                    if (meta_ids is None) or (database_id not in self.used_annotations): continue
+                    if (meta_ids is None) or (database_id not in self.used_annotations):
+                        continue
                     flattened_ids = []
                     for meta_id in meta_ids:
                         if type(meta_id) == list:
@@ -291,19 +485,29 @@ class DataCollector:
                             flattened_ids.append(meta_id)
                     for meta_id in flattened_ids:
                         meta_id = meta_id.replace("META:", "")
-                        if (meta_id not in DB_ids[database_id]["ids"]):
-                            if (meta_id in DB_ids[database_id]["old_ids"]):
-                                _, new_ids = self.interfaces[database_id].update_ids(meta_id)
+                        if meta_id not in DB_ids[database_id]["ids"]:
+                            if meta_id in DB_ids[database_id]["old_ids"]:
+                                _, new_ids = self.interfaces[database_id].update_ids(
+                                    meta_id
+                                )
                             else:
                                 new_ids = [meta_id]
                             for meta_id in new_ids:
-                                back_references = self.interfaces[database_id].get_other_references(meta_id, self.used_annotations)
+                                back_references = self.interfaces[
+                                    database_id
+                                ].get_other_references(meta_id, self.used_annotations)
                                 back_ref = back_references.get(next_id[0], [])
-                                strict_condition = self.strict_linkback or len(back_references) != 0
-                                if (not strict_condition) or ((not back_ref is None) and (next_id[1] in back_ref)):
+                                strict_condition = (
+                                    self.strict_linkback or len(back_references) != 0
+                                )
+                                if (not strict_condition) or (
+                                    (not back_ref is None) and (next_id[1] in back_ref)
+                                ):
                                     DB_ids[database_id]["ids"].add(meta_id)
                                     check_list.add((database_id, meta_id))
-                                    logging.info(f"Found new id {meta_id} in {database_id} from {next_id} for {metabolite.id}")
+                                    logging.info(
+                                        f"Found new id {meta_id} in {database_id} from {next_id} for {metabolite.id}"
+                                    )
             except KeyboardInterrupt:
                 raise
             except Exception as e:

--- a/MCC/DataCollection/DataCollection.py
+++ b/MCC/DataCollection/DataCollection.py
@@ -4,7 +4,6 @@ import logging
 import time
 from tqdm import tqdm
 import dill
-import os
 
 from ..ModelInterface.ModelInterface import ModelInterface
 from ..core import Formula, Metabolite
@@ -20,6 +19,18 @@ default_interfaces = {"metanetx.chemical" : MetaNetXInterface,
                     "seed.compound" : ModelSEEDInterface,
                     "biocyc" : BioCycInterface
                     }
+
+
+def default_data_path():
+    """
+    Returns a stable cache directory for downloaded database artifacts.
+    """
+    xdg_cache = os.environ.get("XDG_CACHE_HOME")
+    if xdg_cache:
+        cache_root = xdg_cache
+    else:
+        cache_root = os.path.join(os.path.expanduser("~"), ".cache")
+    return os.path.join(cache_root, "MassChargeCuration")
 
 
 class DataCollector:
@@ -43,7 +54,7 @@ class DataCollector:
         cache_ids (str): Optional; Name of cache file for the metabolite ids in the data_path. If given, will load the ids from the cache file instead of updating them.
     """
 
-    def __init__(self, model = None, data_path = "./data", update_ids = False, gather_information = True, used_annotations = None, no_local = False, biocyc_path = None, cache_ids = None):
+    def __init__(self, model = None, data_path = None, update_ids = False, gather_information = True, used_annotations = None, no_local = False, biocyc_path = None, cache_ids = None):
         if model is None:
             logging.warning(f"No model was passed to DataCollector. This is most likely not intended.")
         else:
@@ -51,13 +62,13 @@ class DataCollector:
         self.no_local = no_local
         self.interfaces = {}
         self.used_annotations = list(default_interfaces.keys()) if used_annotations is None else used_annotations
-        self.data_path = data_path
+        self.data_path = default_data_path() if data_path is None else data_path
         self.strict_linkback = True
         try:
             os.makedirs(self.data_path)
         except OSError:
             pass
-        self._load_default_interfaces(data_path, biocyc_path)
+        self._load_default_interfaces(self.data_path, biocyc_path)
         self.assignments = {}
         self.allow_undefined_charge = True
         if update_ids:

--- a/MCC/DataCollection/Requests/BiGG.py
+++ b/MCC/DataCollection/Requests/BiGG.py
@@ -17,6 +17,7 @@ class BiGGInterface(DatabaseInterface):
         """
         if self.no_local:
             self.BiGG_dict = {}
+            return
         try:
             with open(f"{self.data_path}/BiGG_Database.json", "r") as f:
                 self.BiGG_dict = json.loads(f.read())
@@ -39,6 +40,10 @@ class BiGGInterface(DatabaseInterface):
 
             with open(f"{self.data_path}/BiGG_Database.json", "r") as f:
                 self.BiGG_dict = json.loads(f.read())
+
+    def _persist_db(self):
+        with open(f"{self.data_path}/BiGG_Database.json", "w") as db_file:
+            db_file.write(json.dumps(self.BiGG_dict))
 
     def get_assignments_by_id(self, meta_id):
         if not meta_id.startswith("M_"):
@@ -105,6 +110,7 @@ class BiGGInterface(DatabaseInterface):
         Online fallback function if a meta_id cannot be found in the offline databases.
         """
         base_url = 'http://bigg.ucsd.edu/api/v2/universal/metabolites/{}'
+        cache_key = meta_id if meta_id.startswith("M_") else f"M_{meta_id}"
         # since generally "M_" is not included in the meta_id in BiGG
         if meta_id.startswith("M_"):
             meta_id = meta_id[2:]
@@ -124,4 +130,12 @@ class BiGGInterface(DatabaseInterface):
         except json.decoder.JSONDecodeError:
             charges = [None]
             formulae = [None]
-        return set((formula, charge) for formula in formulae for charge in charges)
+        assignments = set((formula, charge) for formula in formulae for charge in charges)
+        if len(assignments) > 0 and cache_key not in self.BiGG_dict:
+            self.BiGG_dict[cache_key] = {"names": [], "annotations": {}}
+        if len(assignments) > 0:
+            cached = self.BiGG_dict[cache_key]
+            for idx, assignment in enumerate(sorted(assignments)):
+                cached[f"online_{idx}"] = list(assignment)
+            self._persist_db()
+        return assignments

--- a/MCC/DataCollection/Requests/BiGG.py
+++ b/MCC/DataCollection/Requests/BiGG.py
@@ -1,11 +1,13 @@
 import json
 import requests
 import os
+import logging
 from ...ModelInterface.ModelInterface import ModelInterface
 from .databaseInterface import DatabaseInterface
 
+
 class BiGGInterface(DatabaseInterface):
-    def __init__(self, data_path, no_local = False, biocyc_base_path = None):
+    def __init__(self, data_path, no_local=False, biocyc_base_path=None):
         self.data_path = data_path
         self.no_local = no_local
         self.biocyc_base_path = biocyc_base_path
@@ -16,16 +18,28 @@ class BiGGInterface(DatabaseInterface):
         Loads in (or on demand downloads and creates) the BiGG database file.
         """
         if self.no_local:
+            logging.info(
+                "BiGG local cache disabled (no_local=True); using online fallback only."
+            )
             self.BiGG_dict = {}
             return
         try:
+            logging.info(f"Loading BiGG cache from {self.data_path}/BiGG_Database.json")
             with open(f"{self.data_path}/BiGG_Database.json", "r") as f:
                 self.BiGG_dict = json.loads(f.read())
+            logging.info(
+                f"Loaded BiGG cache with {len(self.BiGG_dict)} metabolite entries."
+            )
         except FileNotFoundError:
-            result = requests.get("http://bigg.ucsd.edu/api/v2/models") 
+            logging.info(
+                "BiGG cache not found. Downloading BiGG models and consolidating local cache; this may take a while."
+            )
+            result = requests.get("http://bigg.ucsd.edu/api/v2/models")
             if result.status_code != 200:
                 result.raise_for_status()  # Will only raise for 4xx codes, so...
-                raise RuntimeError(f"Request to http://bigg.ucsd.edu/api/v2/models returned status code {result.status_code}")
+                raise RuntimeError(
+                    f"Request to http://bigg.ucsd.edu/api/v2/models returned status code {result.status_code}"
+                )
             base_url = "http://bigg.ucsd.edu/static/models/{}.xml"
             base_path = f"{self.data_path}/BiGG_models"
             try:
@@ -40,6 +54,9 @@ class BiGGInterface(DatabaseInterface):
 
             with open(f"{self.data_path}/BiGG_Database.json", "r") as f:
                 self.BiGG_dict = json.loads(f.read())
+            logging.info(
+                f"Built BiGG cache with {len(self.BiGG_dict)} metabolite entries."
+            )
 
     def _persist_db(self):
         with open(f"{self.data_path}/BiGG_Database.json", "w") as db_file:
@@ -51,22 +68,34 @@ class BiGGInterface(DatabaseInterface):
         sub_dict = self.BiGG_dict.get(meta_id, {})
         formulae = set()
         for key, value in sub_dict.items():
-            if key in ["names", "annotations"] or (value[0] == ""): continue
+            if key in ["names", "annotations"] or (value[0] == ""):
+                continue
             else:
                 formulae.add(tuple(value))
         if len(formulae) == 0:
             formulae = self.get_BiGG_information(meta_id)
-        return formulae 
-    
+        return formulae
+
     def search_identifier(self, names, other_ids):
         found = set()
         for key, values in self.BiGG_dict.items():
-            if any(name in values['names'] for name in names) or any([(db_id in values['annotations']) and values['annotations'][db_id] == other_ids[db_id] for db_id in other_ids]):
+            if any(name in values["names"] for name in names) or any(
+                [
+                    (db_id in values["annotations"])
+                    and values["annotations"][db_id] == other_ids[db_id]
+                    for db_id in other_ids
+                ]
+            ):
                 found.add(key)
         return list(found)
 
     def get_other_references(self, id, relevant_dbs):
-        return {database_id: self.BiGG_dict.get(id, {}).get("annotations", {}).get(database_id, None) for database_id in relevant_dbs}
+        return {
+            database_id: self.BiGG_dict.get(id, {})
+            .get("annotations", {})
+            .get(database_id, None)
+            for database_id in relevant_dbs
+        }
 
     def consolidate_BiGG(self):
         """
@@ -75,15 +104,23 @@ class BiGGInterface(DatabaseInterface):
         BiGG_Database = {}
         incomplete_models = {}
         for model_name in os.listdir(f"{self.data_path}/BiGG_models")[:3]:
-            model_interface = ModelInterface(f"{self.data_path}/BiGG_models/{model_name}")
+            model_interface = ModelInterface(
+                f"{self.data_path}/BiGG_models/{model_name}"
+            )
             for metabolite in model_interface.metabolites.values():
                 meta_dict = BiGG_Database.get(metabolite.id[:-2], {})
                 if (metabolite.formula is None) or (metabolite.charge is None):
                     model_dict = incomplete_models.get(model_name, {})
-                    model_dict[metabolite.id] = (str(metabolite.formula), metabolite.charge)
+                    model_dict[metabolite.id] = (
+                        str(metabolite.formula),
+                        metabolite.charge,
+                    )
                     incomplete_models[model_name] = model_dict
                     continue
-                meta_dict[model_name[:-4]] = (str(metabolite.formula), metabolite.charge)
+                meta_dict[model_name[:-4]] = (
+                    str(metabolite.formula),
+                    metabolite.charge,
+                )
                 annotations = meta_dict.get("annotations", {})
                 names = meta_dict.get("names", set())
                 names.add(metabolite.name)
@@ -99,17 +136,17 @@ class BiGGInterface(DatabaseInterface):
         for metabolite in BiGG_Database:
             for key, value in BiGG_Database[metabolite]["annotations"].items():
                 BiGG_Database[metabolite]["annotations"][key] = list(value)
-            BiGG_Database[metabolite]["names"] = list(BiGG_Database[metabolite]["names"])
+            BiGG_Database[metabolite]["names"] = list(
+                BiGG_Database[metabolite]["names"]
+            )
         with open(f"{self.data_path}/BiGG_Database.json", "w") as db_file:
-            db_file.write(json.dumps(BiGG_Database)) 
-
-    
+            db_file.write(json.dumps(BiGG_Database))
 
     def get_BiGG_information(self, meta_id):
         """
         Online fallback function if a meta_id cannot be found in the offline databases.
         """
-        base_url = 'http://bigg.ucsd.edu/api/v2/universal/metabolites/{}'
+        base_url = "http://bigg.ucsd.edu/api/v2/universal/metabolites/{}"
         cache_key = meta_id if meta_id.startswith("M_") else f"M_{meta_id}"
         # since generally "M_" is not included in the meta_id in BiGG
         if meta_id.startswith("M_"):
@@ -118,11 +155,13 @@ class BiGGInterface(DatabaseInterface):
 
         if result.status_code != 200:
             result.raise_for_status()  # Will only raise for 4xx codes, so...
-            raise RuntimeError(f"Request to {base_url.format(meta_id)} returned status code {result.status_code}")
+            raise RuntimeError(
+                f"Request to {base_url.format(meta_id)} returned status code {result.status_code}"
+            )
         try:
             metabolite_json = result.json()
-            charges = metabolite_json['charges']
-            formulae = metabolite_json['formulae']
+            charges = metabolite_json["charges"]
+            formulae = metabolite_json["formulae"]
             if len(charges) == 0:
                 charges = [None]
             if len(formulae) == 0:
@@ -130,7 +169,9 @@ class BiGGInterface(DatabaseInterface):
         except json.decoder.JSONDecodeError:
             charges = [None]
             formulae = [None]
-        assignments = set((formula, charge) for formula in formulae for charge in charges)
+        assignments = set(
+            (formula, charge) for formula in formulae for charge in charges
+        )
         if len(assignments) > 0 and cache_key not in self.BiGG_dict:
             self.BiGG_dict[cache_key] = {"names": [], "annotations": {}}
         if len(assignments) > 0:

--- a/MCC/DataCollection/Requests/BioCyc.py
+++ b/MCC/DataCollection/Requests/BioCyc.py
@@ -4,6 +4,7 @@ import json
 import requests
 import xml.etree.ElementTree as ET
 import logging
+import time
 import pandas as pd
 from io import StringIO
 
@@ -14,8 +15,9 @@ from .databaseInterface import DatabaseInterface
 replace_capital_ids = re.compile(r"([A-Z])([A-Z])")
 remove_1 = re.compile(r"([A-Z][a-z]?)(1)([A-Z]|$)")
 
+
 class BioCycInterface(DatabaseInterface):
-    def __init__(self, data_path, no_local = False, biocyc_base_path = None):
+    def __init__(self, data_path, no_local=False, biocyc_base_path=None):
         self.data_path = data_path
         self.no_local = no_local
         self.biocyc_base_path = biocyc_base_path
@@ -25,31 +27,53 @@ class BioCycInterface(DatabaseInterface):
         """
         Loads the BioCyc database files (and on demand consolidates them).
         """
-        if self.no_local: 
+        start = time.perf_counter()
+        if self.no_local:
+            logging.info(
+                "BioCyc local cache disabled (no_local=True); using online fallback only."
+            )
             self.BioCyc_dict = {}
             return
         try:
+            logging.info(f"Loading BioCyc cache from {self.data_path}/BioCyc.json")
             with open(f"{self.data_path}/BioCyc.json", "r") as f:
                 self.BioCyc_dict = json.loads(f.read())
+            logging.info(f"Loaded BioCyc cache with {len(self.BioCyc_dict)} entries.")
         except FileNotFoundError:
             if not self.biocyc_base_path is None:
+                logging.info(
+                    f"BioCyc cache not found. Consolidating from local BioCyc base path: {self.biocyc_base_path}"
+                )
                 self.consolidate_BioCyc()
                 with open(f"{self.data_path}/BioCyc.json", "r") as f:
                     self.BioCyc_dict = json.loads(f.read())
+                logging.info(
+                    f"Built BioCyc cache with {len(self.BioCyc_dict)} entries."
+                )
             else:
+                logging.info(
+                    "BioCyc cache not found and no biocyc_base_path provided. Continuing with empty BioCyc cache."
+                )
                 self.BioCyc_dict = {}
+        logging.info(f"[{time.perf_counter() - start:.3f} s] BioCyc database ready.")
 
     def _persist_db(self):
-        with open(f"{self.data_path}/BioCyc.json" ,"w") as f:
+        with open(f"{self.data_path}/BioCyc.json", "w") as f:
             f.write(json.dumps(self.BioCyc_dict))
-            
+
     def get_assignments_by_id(self, meta_id):
-        formula = self.BioCyc_dict.get(meta_id.replace("META:", ""), {}).get("formula", None)
-        charge = self.BioCyc_dict.get(meta_id.replace("META:", ""), {}).get("charge", None)
+        formula = self.BioCyc_dict.get(meta_id.replace("META:", ""), {}).get(
+            "formula", None
+        )
+        charge = self.BioCyc_dict.get(meta_id.replace("META:", ""), {}).get(
+            "charge", None
+        )
         if formula is None:
             result = self.get_BioCyc_information(meta_id)
-            if result is None: return result
-            else: return [result]
+            if result is None:
+                return result
+            else:
+                return [result]
         return [(formula, charge)]
 
     def get_BioCyc_information(self, meta_id):
@@ -59,57 +83,79 @@ class BioCycInterface(DatabaseInterface):
         Args:
             meta_id (str): Id of the metabolite for which we want to fetch information.
         """
-        base_url = 'https://websvc.biocyc.org/getxml?{}&detail=low'
+        base_url = "https://websvc.biocyc.org/getxml?{}&detail=low"
         try:
             answer = requests.get(base_url.format(meta_id))
-            logging.debug(f"Could not find entry {meta_id} in local BioCyc file. Trying to fetch from {base_url.format(meta_id)}")
+            logging.debug(
+                f"Could not find entry {meta_id} in local BioCyc file. Trying to fetch from {base_url.format(meta_id)}"
+            )
             xml_tree = ET.fromstring(answer.text)
             formula = xml_tree.find(".//formula")
             charge = xml_tree.find(".//Compound/cml/molecule")
             if not charge is None:
-                charge = int(charge.attrib['formalCharge'])
+                charge = int(charge.attrib["formalCharge"])
             if not formula is None:
-                formula = formula.attrib['concise'].replace(" ", "")
-                formula = replace_capital_ids.sub(lambda pat: pat.group(1) + pat.group(2).lower(), formula)
+                formula = formula.attrib["concise"].replace(" ", "")
+                formula = replace_capital_ids.sub(
+                    lambda pat: pat.group(1) + pat.group(2).lower(), formula
+                )
                 formula = remove_1.sub(r"\1\3", formula)
                 self.BioCyc_dict[meta_id.replace("META:", "")] = {
                     "names": [],
                     "formula": formula,
                     "charge": charge,
                     "db_links": {},
-                    "type": "compound"
+                    "type": "compound",
                 }
                 self._persist_db()
                 return (formula, charge)
-        except ET.ParseError: #Dead links return HTML files instead of XML
+        except ET.ParseError:  # Dead links return HTML files instead of XML
             return
 
     def search_identifier(self, names, other_ids):
-        id_mapping = {"metanetx.chemical" : "MetaNetX",
-                 "bigg.metabolite" : "BiGG",
-                 "seed.compound" : "Seed",
-                 "sabiork.compound": None,
-                 "biocyc" : "BioCyc" # somewhat redundant
-                 }
-        id_list = [(db, identifier) for db, value in other_ids.items() for identifier in value["ids"]]
-        query = "\n".join([*names, *[f"{id_mapping[key]}:{value} " for key, value in id_list]])
-        if len(names) == 0: return None
-        response = requests.post("https://biocyc.org/META/metabolite-translation-service?=file", files = {"file" : query})
-        df = pd.read_csv(StringIO(response.text), sep = "\t")
+        id_mapping = {
+            "metanetx.chemical": "MetaNetX",
+            "bigg.metabolite": "BiGG",
+            "seed.compound": "Seed",
+            "sabiork.compound": None,
+            "biocyc": "BioCyc",  # somewhat redundant
+        }
+        id_list = [
+            (db, identifier)
+            for db, value in other_ids.items()
+            for identifier in value["ids"]
+        ]
+        query = "\n".join(
+            [*names, *[f"{id_mapping[key]}:{value} " for key, value in id_list]]
+        )
+        if len(names) == 0:
+            return None
+        response = requests.post(
+            "https://biocyc.org/META/metabolite-translation-service?=file",
+            files={"file": query},
+        )
+        df = pd.read_csv(StringIO(response.text), sep="\t")
         if not "Result" in df.columns:
             return []
         else:
-            return [f"META:{biocyc_id}" for biocyc_id in df[df["Result"] == "success"].BioCyc.unique()]
+            return [
+                f"META:{biocyc_id}"
+                for biocyc_id in df[df["Result"] == "success"].BioCyc.unique()
+            ]
 
     def get_other_references(self, id, relevant_dbs):
-        id_mapping = {"METANETX" : "metanetx.chemical", # somewhat redundant
-                    "BIGG" : "bigg.metabolite",
-                    "SEED" : "seed.compound"
-                    }
+        id_mapping = {
+            "METANETX": "metanetx.chemical",  # somewhat redundant
+            "BIGG": "bigg.metabolite",
+            "SEED": "seed.compound",
+        }
         result = {}
         for database_id in id_mapping:
-            links = self.BioCyc_dict.get(id, {}).get("db_links", {}).get(database_id, None)
-            if links is None: continue
+            links = (
+                self.BioCyc_dict.get(id, {}).get("db_links", {}).get(database_id, None)
+            )
+            if links is None:
+                continue
             else:
                 result[id_mapping[database_id]] = links.split(";")
         return result
@@ -120,28 +166,34 @@ class BioCycInterface(DatabaseInterface):
         """
         compound_file_name = f"{self.biocyc_base_path}/compounds.dat"
         class_file_name = f"{self.biocyc_base_path}/classes.dat"
-        with codecs.open(compound_file_name, 'r', encoding='utf-8', errors='ignore') as fdata:
+        with codecs.open(
+            compound_file_name, "r", encoding="utf-8", errors="ignore"
+        ) as fdata:
             classes = fdata.read().split("//\n")[1:]
             classes_split = [c.split("\n") for c in classes]
             compound_dict = {}
             for split in classes_split:
                 meta_id, information = parse_biocyc_compound(split)
                 compound_dict[meta_id] = information
-        with codecs.open(class_file_name, 'r', encoding='utf-8', errors='ignore') as fdata:
+        with codecs.open(
+            class_file_name, "r", encoding="utf-8", errors="ignore"
+        ) as fdata:
             classes = fdata.read().split("//\n")[1:]
             classes_split = [c.split("\n") for c in classes]
             for split in classes_split:
                 meta_id, information = parse_biocyc_class(split)
                 compound_dict[meta_id] = information
 
-        with open(f"{self.data_path}/BioCyc.json" ,"w") as f:
+        with open(f"{self.data_path}/BioCyc.json", "w") as f:
             f.write(json.dumps(compound_dict))
+
 
 find_id = re.compile(r"UNIQUE-ID - (.*)")
 find_formula = re.compile(r"CHEMICAL-FORMULA - \((\S+) (\d+)\)")
 find_charge = re.compile(r"ATOM-CHARGES - \((\d+) (\S+)\)")
 find_name = re.compile(r"(?:COMMON-NAME|SYNONYMS) - (.*)")
 find_link = re.compile(r'DBLINKS - \((\S+) "(.*)"')
+
 
 def parse_biocyc_compound(compound_split):
     """
@@ -156,18 +208,27 @@ def parse_biocyc_compound(compound_split):
         if not (found := find_id.search(line)) is None:
             meta_id = found.groups()[0]
         if not (found := find_name.search(line)) is None:
-            names.append(found.groups()[0].replace("<sup>", "").replace("</sup>", "").replace("<i>", "").replace("</i>", ""))
+            names.append(
+                found.groups()[0]
+                .replace("<sup>", "")
+                .replace("</sup>", "")
+                .replace("<i>", "")
+                .replace("</i>", "")
+            )
         if not (found := find_formula.search(line)) is None:
             elements[found.groups()[0]] = int(found.groups()[1])
         if not (found := find_charge.search(line)) is None:
             charge += int(found.groups()[1])
         if not (found := find_link.search(line)) is None:
             db_links[found.groups()[0]] = found.groups()[1]
-    return meta_id, {"names" : names,
-                    "formula" : str(Formula(elements)),
-                    "charge" : charge,
-                    "db_links" : db_links,
-                    "type" : "compound"}
+    return meta_id, {
+        "names": names,
+        "formula": str(Formula(elements)),
+        "charge": charge,
+        "db_links": db_links,
+        "type": "compound",
+    }
+
 
 def parse_biocyc_class(compound_split):
     """
@@ -180,6 +241,11 @@ def parse_biocyc_class(compound_split):
         if not (found := find_id.search(line)) is None:
             meta_id = found.groups()[0]
         if not (found := find_name.search(line)) is None:
-            names.append(found.groups()[0].replace("<sup>", "").replace("</sup>", "").replace("<i>", "").replace("</i>", ""))
-    return meta_id, {"names" : names,
-                    "type" : "class"}
+            names.append(
+                found.groups()[0]
+                .replace("<sup>", "")
+                .replace("</sup>", "")
+                .replace("<i>", "")
+                .replace("</i>", "")
+            )
+    return meta_id, {"names": names, "type": "class"}

--- a/MCC/DataCollection/Requests/BioCyc.py
+++ b/MCC/DataCollection/Requests/BioCyc.py
@@ -38,6 +38,10 @@ class BioCycInterface(DatabaseInterface):
                     self.BioCyc_dict = json.loads(f.read())
             else:
                 self.BioCyc_dict = {}
+
+    def _persist_db(self):
+        with open(f"{self.data_path}/BioCyc.json" ,"w") as f:
+            f.write(json.dumps(self.BioCyc_dict))
             
     def get_assignments_by_id(self, meta_id):
         formula = self.BioCyc_dict.get(meta_id.replace("META:", ""), {}).get("formula", None)
@@ -68,6 +72,14 @@ class BioCycInterface(DatabaseInterface):
                 formula = formula.attrib['concise'].replace(" ", "")
                 formula = replace_capital_ids.sub(lambda pat: pat.group(1) + pat.group(2).lower(), formula)
                 formula = remove_1.sub(r"\1\3", formula)
+                self.BioCyc_dict[meta_id.replace("META:", "")] = {
+                    "names": [],
+                    "formula": formula,
+                    "charge": charge,
+                    "db_links": {},
+                    "type": "compound"
+                }
+                self._persist_db()
                 return (formula, charge)
         except ET.ParseError: #Dead links return HTML files instead of XML
             return
@@ -171,4 +183,3 @@ def parse_biocyc_class(compound_split):
             names.append(found.groups()[0].replace("<sup>", "").replace("</sup>", "").replace("<i>", "").replace("</i>", ""))
     return meta_id, {"names" : names,
                     "type" : "class"}
-

--- a/MCC/DataCollection/Requests/MetaNetX.py
+++ b/MCC/DataCollection/Requests/MetaNetX.py
@@ -1,6 +1,7 @@
 import requests
 import logging
 import time
+import os
 import pandas as pd
 from difflib import SequenceMatcher
 from ...util import progress_download
@@ -17,11 +18,17 @@ class MetaNetXInterface(DatabaseInterface):
         self.prop_dict = {}
         map_start = time.perf_counter()
         logging.info("Building MetaNetX property lookup dictionary...")
-
-        def fill_dict(row):
-            self.prop_dict[row["#ID"]] = (row["formula"], row["charge"])
-
-        self.prop_df.apply(fill_dict, axis=1)
+        if len(self.prop_df) > 0:
+            self.prop_dict = dict(
+                zip(
+                    self.prop_df["#ID"],
+                    zip(self.prop_df["formula"], self.prop_df["charge"]),
+                )
+            )
+        else:
+            logging.info(
+                "MetaNetX property table is empty; lookup dictionary remains empty."
+            )
         logging.info(
             f"[{time.perf_counter() - map_start:.3f} s] Built MetaNetX property lookup with {len(self.prop_dict)} entries."
         )
@@ -33,19 +40,60 @@ class MetaNetXInterface(DatabaseInterface):
         """
         Reads the last comment line (starting with #) from a tsv file and returns the column names as a list.
         """
-        with open(filepath, "r") as f:
-            lines = f.readlines()
-        # Find last comment line
         header_line = None
-        for line in reversed(lines):
-            if line.startswith("#"):
-                header_line = line.strip()
-                break
+        with open(filepath, "r") as f:
+            for line in f:
+                if line.startswith("#"):
+                    header_line = line.strip()
+                elif header_line is not None:
+                    break
         if header_line is None:
             raise ValueError(f"No header line found in {filepath}")
         # Remove leading # and split by tab
         columns = [col.strip() for col in header_line.split("\t")]
         return columns
+
+    def _load_cached_table(self, table_name, tsv_path):
+        cache_path = f"{tsv_path}.pkl"
+        tsv_mtime = os.path.getmtime(tsv_path)
+
+        if os.path.exists(cache_path):
+            cache_mtime = os.path.getmtime(cache_path)
+            if cache_mtime >= tsv_mtime:
+                cache_load_start = time.perf_counter()
+                logging.info(
+                    f"Loading MetaNetX {table_name} binary cache from {cache_path}"
+                )
+                try:
+                    df = pd.read_pickle(cache_path)
+                    logging.info(
+                        f"[{time.perf_counter() - cache_load_start:.3f} s] Loaded MetaNetX {table_name} binary cache with {len(df)} rows."
+                    )
+                    return df
+                except Exception as exc:
+                    logging.warning(
+                        f"Failed loading MetaNetX {table_name} binary cache ({exc}). Re-parsing TSV."
+                    )
+
+        tsv_load_start = time.perf_counter()
+        logging.info(f"Parsing MetaNetX {table_name} TSV from {tsv_path}")
+        tsv_columns = self._get_tsv_columns(tsv_path)
+        df = pd.read_csv(tsv_path, sep="\t", comment="#", names=tsv_columns)
+        logging.info(
+            f"[{time.perf_counter() - tsv_load_start:.3f} s] Parsed MetaNetX {table_name} TSV with {len(df)} rows."
+        )
+
+        try:
+            write_start = time.perf_counter()
+            df.to_pickle(cache_path)
+            logging.info(
+                f"[{time.perf_counter() - write_start:.3f} s] Wrote MetaNetX {table_name} binary cache to {cache_path}"
+            )
+        except Exception as exc:
+            logging.warning(
+                f"Failed writing MetaNetX {table_name} binary cache ({exc}). Continuing with TSV-backed dataframe."
+            )
+        return df
 
     def load_metanetx_db(self):
         start = time.perf_counter()
@@ -62,68 +110,38 @@ class MetaNetXInterface(DatabaseInterface):
         # chem_xref.tsv
         xref_path = f"{self.data_path}/chem_xref.tsv"
         try:
-            logging.info(f"Loading MetaNetX xref cache from {xref_path}")
-            xref_columns = self._get_tsv_columns(xref_path)
-            self.xref_df = pd.read_csv(
-                xref_path, sep="\t", comment="#", names=xref_columns
-            )
-            logging.info(f"Loaded MetaNetX xref cache with {len(self.xref_df)} rows.")
+            self.xref_df = self._load_cached_table("xref", xref_path)
         except FileNotFoundError:
             logging.warning(
                 "MetaNetX xref database not found. Downloading MetaNetX xref database, this might take a while..."
             )
             progress_download(base_url.format("chem_xref.tsv"), xref_path)
-            xref_columns = self._get_tsv_columns(xref_path)
-            self.xref_df = pd.read_csv(
-                xref_path, sep="\t", comment="#", names=xref_columns
-            )
-            logging.info(
-                f"Downloaded and loaded MetaNetX xref cache with {len(self.xref_df)} rows."
-            )
+            self.xref_df = self._load_cached_table("xref", xref_path)
+            logging.info("Downloaded and initialized MetaNetX xref cache.")
 
         # chem_depr.tsv
         depr_path = f"{self.data_path}/chem_depr.tsv"
         try:
-            logging.info(f"Loading MetaNetX depr cache from {depr_path}")
-            depr_columns = self._get_tsv_columns(depr_path)
-            self.depr_df = pd.read_csv(
-                depr_path, sep="\t", comment="#", names=depr_columns
-            )
-            logging.info(f"Loaded MetaNetX depr cache with {len(self.depr_df)} rows.")
+            self.depr_df = self._load_cached_table("depr", depr_path)
         except FileNotFoundError:
             logging.warning(
                 "MetaNetX depr database not found. Downloading MetaNetX depr database, this might take a while..."
             )
             progress_download(base_url.format("chem_depr.tsv"), depr_path)
-            depr_columns = self._get_tsv_columns(depr_path)
-            self.depr_df = pd.read_csv(
-                depr_path, sep="\t", comment="#", names=depr_columns
-            )
-            logging.info(
-                f"Downloaded and loaded MetaNetX depr cache with {len(self.depr_df)} rows."
-            )
+            self.depr_df = self._load_cached_table("depr", depr_path)
+            logging.info("Downloaded and initialized MetaNetX depr cache.")
 
         # chem_prop.tsv
         prop_path = f"{self.data_path}/chem_prop.tsv"
         try:
-            logging.info(f"Loading MetaNetX prop cache from {prop_path}")
-            prop_columns = self._get_tsv_columns(prop_path)
-            self.prop_df = pd.read_csv(
-                prop_path, sep="\t", comment="#", names=prop_columns
-            )
-            logging.info(f"Loaded MetaNetX prop cache with {len(self.prop_df)} rows.")
+            self.prop_df = self._load_cached_table("prop", prop_path)
         except FileNotFoundError:
             logging.warning(
                 "MetaNetX prop database not found. Downloading MetaNetX prop database, this might take a while..."
             )
             progress_download(base_url.format("chem_prop.tsv"), prop_path)
-            prop_columns = self._get_tsv_columns(prop_path)
-            self.prop_df = pd.read_csv(
-                prop_path, sep="\t", comment="#", names=prop_columns
-            )
-            logging.info(
-                f"Downloaded and loaded MetaNetX prop cache with {len(self.prop_df)} rows."
-            )
+            self.prop_df = self._load_cached_table("prop", prop_path)
+            logging.info("Downloaded and initialized MetaNetX prop cache.")
         logging.info(f"[{time.perf_counter() - start:.3f} s] MetaNetX database ready.")
 
     def get_assignments_by_id(self, meta_id):

--- a/MCC/DataCollection/Requests/MetaNetX.py
+++ b/MCC/DataCollection/Requests/MetaNetX.py
@@ -1,22 +1,33 @@
 import requests
 import logging
+import time
 import pandas as pd
 from difflib import SequenceMatcher
 from ...util import progress_download
 
 from .databaseInterface import DatabaseInterface
 
+
 class MetaNetXInterface(DatabaseInterface):
-    def __init__(self, data_path, no_local = False):
+    def __init__(self, data_path, no_local=False):
+        init_start = time.perf_counter()
         self.data_path = data_path
         self.no_local = no_local
         self.load_metanetx_db()
         self.prop_dict = {}
+        map_start = time.perf_counter()
+        logging.info("Building MetaNetX property lookup dictionary...")
+
         def fill_dict(row):
-            self.prop_dict[row['#ID']] = (row["formula"], row["charge"])
-        self.prop_df.apply(fill_dict, axis = 1)
+            self.prop_dict[row["#ID"]] = (row["formula"], row["charge"])
 
-
+        self.prop_df.apply(fill_dict, axis=1)
+        logging.info(
+            f"[{time.perf_counter() - map_start:.3f} s] Built MetaNetX property lookup with {len(self.prop_dict)} entries."
+        )
+        logging.info(
+            f"[{time.perf_counter() - init_start:.3f} s] MetaNetX interface initialization complete."
+        )
 
     def _get_tsv_columns(self, filepath):
         """
@@ -37,8 +48,11 @@ class MetaNetXInterface(DatabaseInterface):
         return columns
 
     def load_metanetx_db(self):
+        start = time.perf_counter()
         if self.no_local:
-            logging.warning("MetaNetX interface is currently only implemented to download the entire database.")
+            logging.warning(
+                "MetaNetX interface is currently only implemented to download the entire database."
+            )
             self.xref_df = pd.DataFrame()
             self.depr_df = pd.DataFrame()
             self.prop_df = pd.DataFrame()
@@ -48,35 +62,69 @@ class MetaNetXInterface(DatabaseInterface):
         # chem_xref.tsv
         xref_path = f"{self.data_path}/chem_xref.tsv"
         try:
+            logging.info(f"Loading MetaNetX xref cache from {xref_path}")
             xref_columns = self._get_tsv_columns(xref_path)
-            self.xref_df = pd.read_csv(xref_path, sep="\t", comment="#", names=xref_columns)
+            self.xref_df = pd.read_csv(
+                xref_path, sep="\t", comment="#", names=xref_columns
+            )
+            logging.info(f"Loaded MetaNetX xref cache with {len(self.xref_df)} rows.")
         except FileNotFoundError:
-            logging.warning("MetaNetX xref database not found. Downloading MetaNetX xref database, this might take a while...")
+            logging.warning(
+                "MetaNetX xref database not found. Downloading MetaNetX xref database, this might take a while..."
+            )
             progress_download(base_url.format("chem_xref.tsv"), xref_path)
             xref_columns = self._get_tsv_columns(xref_path)
-            self.xref_df = pd.read_csv(xref_path, sep="\t", comment="#", names=xref_columns)
+            self.xref_df = pd.read_csv(
+                xref_path, sep="\t", comment="#", names=xref_columns
+            )
+            logging.info(
+                f"Downloaded and loaded MetaNetX xref cache with {len(self.xref_df)} rows."
+            )
 
         # chem_depr.tsv
         depr_path = f"{self.data_path}/chem_depr.tsv"
         try:
+            logging.info(f"Loading MetaNetX depr cache from {depr_path}")
             depr_columns = self._get_tsv_columns(depr_path)
-            self.depr_df = pd.read_csv(depr_path, sep="\t", comment="#", names=depr_columns)
+            self.depr_df = pd.read_csv(
+                depr_path, sep="\t", comment="#", names=depr_columns
+            )
+            logging.info(f"Loaded MetaNetX depr cache with {len(self.depr_df)} rows.")
         except FileNotFoundError:
-            logging.warning("MetaNetX depr database not found. Downloading MetaNetX depr database, this might take a while...")
+            logging.warning(
+                "MetaNetX depr database not found. Downloading MetaNetX depr database, this might take a while..."
+            )
             progress_download(base_url.format("chem_depr.tsv"), depr_path)
             depr_columns = self._get_tsv_columns(depr_path)
-            self.depr_df = pd.read_csv(depr_path, sep="\t", comment="#", names=depr_columns)
+            self.depr_df = pd.read_csv(
+                depr_path, sep="\t", comment="#", names=depr_columns
+            )
+            logging.info(
+                f"Downloaded and loaded MetaNetX depr cache with {len(self.depr_df)} rows."
+            )
 
         # chem_prop.tsv
         prop_path = f"{self.data_path}/chem_prop.tsv"
         try:
+            logging.info(f"Loading MetaNetX prop cache from {prop_path}")
             prop_columns = self._get_tsv_columns(prop_path)
-            self.prop_df = pd.read_csv(prop_path, sep="\t", comment="#", names=prop_columns)
+            self.prop_df = pd.read_csv(
+                prop_path, sep="\t", comment="#", names=prop_columns
+            )
+            logging.info(f"Loaded MetaNetX prop cache with {len(self.prop_df)} rows.")
         except FileNotFoundError:
-            logging.warning("MetaNetX prop database not found. Downloading MetaNetX prop database, this might take a while...")
+            logging.warning(
+                "MetaNetX prop database not found. Downloading MetaNetX prop database, this might take a while..."
+            )
             progress_download(base_url.format("chem_prop.tsv"), prop_path)
             prop_columns = self._get_tsv_columns(prop_path)
-            self.prop_df = pd.read_csv(prop_path, sep="\t", comment="#", names=prop_columns)
+            self.prop_df = pd.read_csv(
+                prop_path, sep="\t", comment="#", names=prop_columns
+            )
+            logging.info(
+                f"Downloaded and loaded MetaNetX prop cache with {len(self.prop_df)} rows."
+            )
+        logging.info(f"[{time.perf_counter() - start:.3f} s] MetaNetX database ready.")
 
     def get_assignments_by_id(self, meta_id):
         result = self.prop_dict.get(meta_id, None)
@@ -85,14 +133,23 @@ class MetaNetXInterface(DatabaseInterface):
         return [result]
 
     def search_identifier(self, names, other_ids):
-        id_mapping = {"metanetx.chemical" : "mnx", # somewhat redundant
-                    "bigg.metabolite" : "bigg.metabolite",
-                    "seed.compound" : "seed.compound",
-                    "sabiork.compound": "sabiork.compound",
-                    "biocyc" : "metacyc.compound" 
-                    }
-        other_ids = [f'{id_mapping[db_id]}:{meta_id.replace("META:", "")}' for db_id, meta_ids in other_ids.items() for meta_id in meta_ids["ids"]]
-        return list(self.xref_df["ID"][self.xref_df["#source"].apply(lambda x: x in other_ids)].unique())
+        id_mapping = {
+            "metanetx.chemical": "mnx",  # somewhat redundant
+            "bigg.metabolite": "bigg.metabolite",
+            "seed.compound": "seed.compound",
+            "sabiork.compound": "sabiork.compound",
+            "biocyc": "metacyc.compound",
+        }
+        other_ids = [
+            f"{id_mapping[db_id]}:{meta_id.replace('META:', '')}"
+            for db_id, meta_ids in other_ids.items()
+            for meta_id in meta_ids["ids"]
+        ]
+        return list(
+            self.xref_df["ID"][
+                self.xref_df["#source"].apply(lambda x: x in other_ids)
+            ].unique()
+        )
 
     def update_id(self, id):
         """
@@ -113,14 +170,14 @@ class MetaNetXInterface(DatabaseInterface):
             remove = set()
             new = set()
             for cur_id in current_ids:
-                depr_rows = self.depr_df[self.depr_df['#deprecated_ID'] == (cur_id)]
+                depr_rows = self.depr_df[self.depr_df["#deprecated_ID"] == (cur_id)]
                 if len(depr_rows) > 0:
                     remove.add(cur_id)
                     new.update([metabolite_id for metabolite_id in depr_rows["ID"]])
             current_ids.update(new)
             current_ids -= remove
             old_ids.update(remove)
-        return old_ids, current_ids 
+        return old_ids, current_ids
 
     def update_ids(self, ids, names):
         new_ids = set()
@@ -132,47 +189,63 @@ class MetaNetXInterface(DatabaseInterface):
             filtered_new = []
             for mid in new:
                 found_names = self.prop_df["name"][self.prop_df["#ID"] == mid]
-                if len(found_names) == 0: continue
-                max_sim = max(found_names.apply(lambda x : max([similar(x, name) for name in names_and_ids])))
+                if len(found_names) == 0:
+                    continue
+                max_sim = max(
+                    found_names.apply(
+                        lambda x: max([similar(x, name) for name in names_and_ids])
+                    )
+                )
                 filtered_new.append((max_sim, mid))
-            if len(filtered_new) == 0: continue
+            if len(filtered_new) == 0:
+                continue
             max_similarity = max([scored[0] for scored in filtered_new])
-            if (max_similarity > .8) and (len(new) > 1):
-                filtered_meta_ids = [scored[1] for scored in filtered_new if scored[0] > max_similarity * .9]
-                removed_meta_ids = [scored[1] for scored in filtered_new if scored[0] <= max_similarity * .9]
+            if (max_similarity > 0.8) and (len(new) > 1):
+                filtered_meta_ids = [
+                    scored[1]
+                    for scored in filtered_new
+                    if scored[0] > max_similarity * 0.9
+                ]
+                removed_meta_ids = [
+                    scored[1]
+                    for scored in filtered_new
+                    if scored[0] <= max_similarity * 0.9
+                ]
             else:
                 filtered_meta_ids = []
                 removed_meta_ids = [scored[1] for scored in filtered_new]
-                #logging.warning(f"Max metanetX similarity for {metabolite.id} was less then .8 with {filtered_meta_ids} chosen.")
+                # logging.warning(f"Max metanetX similarity for {metabolite.id} was less then .8 with {filtered_meta_ids} chosen.")
             new_ids.update(filtered_meta_ids)
             new_ids.difference_update(old)
             new_ids.difference_update(removed_meta_ids)
             old_ids.update(removed_meta_ids)
             old_ids.update(old)
         return old_ids, new_ids
-            
-        
 
     def get_other_references(self, id, relevant_dbs):
-        id_mapping = {"mnx" : "metanetx.chemical", # somewhat redundant
-                 "bigg.metabolite" : "bigg.metabolite",
-                 "seed.compound" : "seed.compound",
-                 "sabiork.compound": "sabiork.compound",
-                 "metacyc.compound" : "biocyc"  
-                 }
+        id_mapping = {
+            "mnx": "metanetx.chemical",  # somewhat redundant
+            "bigg.metabolite": "bigg.metabolite",
+            "seed.compound": "seed.compound",
+            "sabiork.compound": "sabiork.compound",
+            "metacyc.compound": "biocyc",
+        }
         references = {}
         out_refs = self.xref_df["#source"][self.xref_df["ID"] == id]
+
         def split_into_identifiers(s):
             colon_index = s.find(":")
             if colon_index > -1:
                 db_identifier = s[:colon_index]
-                meta_id = s[colon_index + 1:]
-                if (db_identifier in id_mapping):
+                meta_id = s[colon_index + 1 :]
+                if db_identifier in id_mapping:
                     db_ref = references.get(db_identifier, set())
                     db_ref.add(meta_id.replace("META:", ""))
                     references[id_mapping[db_identifier]] = db_ref
+
         out_refs.apply(split_into_identifiers)
         return references
+
 
 def similar(a, b):
     """
@@ -187,5 +260,6 @@ def similar(a, b):
         String similarity.
     """
     if a.startswith("L ") or a.startswith("L-"):
-        if not(b.startswith("L ") or b.startswith("L-")): return 0
+        if not (b.startswith("L ") or b.startswith("L-")):
+            return 0
     return SequenceMatcher(None, a.lower(), b.lower()).ratio()

--- a/MCC/DataCollection/Requests/ModelSEED.py
+++ b/MCC/DataCollection/Requests/ModelSEED.py
@@ -23,6 +23,7 @@ class ModelSEEDInterface(DatabaseInterface):
         if self.no_local:
             logging.warning("ModelSEED interface is currently only implemented to download the entire database.")
             self.df = pd.DataFrame()
+            return
         try:
             self.df = pd.read_csv(f"{self.data_path}/ModelSEED_compounds.tsv", sep = "\t", dtype=object)
         except FileNotFoundError:

--- a/MCC/DataCollection/Requests/ModelSEED.py
+++ b/MCC/DataCollection/Requests/ModelSEED.py
@@ -1,40 +1,59 @@
 import re
 import requests
 import logging
+import time
 import pandas as pd
 
 from .databaseInterface import DatabaseInterface
 
+
 class ModelSEEDInterface(DatabaseInterface):
-    def __init__(self, data_path, no_local = False, biocyc_base_path = None):
+    def __init__(self, data_path, no_local=False, biocyc_base_path=None):
         self.data_path = data_path
         self.no_local = no_local
         self.biocyc_base_path = biocyc_base_path
         self.load_db()
         self.ModelSEED_dict = {}
+
         def fill_dict(row):
-            self.ModelSEED_dict[row['id']] = (row["formula"], row["charge"])
-        self.df.apply(fill_dict, axis = 1) 
+            self.ModelSEED_dict[row["id"]] = (row["formula"], row["charge"])
+
+        self.df.apply(fill_dict, axis=1)
 
     def load_db(self):
         """
         Allows to download the modelSEED database for faster access.
         """
+        start = time.perf_counter()
         if self.no_local:
-            logging.warning("ModelSEED interface is currently only implemented to download the entire database.")
+            logging.warning(
+                "ModelSEED interface is currently only implemented to download the entire database."
+            )
             self.df = pd.DataFrame()
             return
         try:
-            self.df = pd.read_csv(f"{self.data_path}/ModelSEED_compounds.tsv", sep = "\t", dtype=object)
+            logging.info(
+                f"Loading ModelSEED cache from {self.data_path}/ModelSEED_compounds.tsv"
+            )
+            self.df = pd.read_csv(
+                f"{self.data_path}/ModelSEED_compounds.tsv", sep="\t", dtype=object
+            )
+            logging.info(f"Loaded ModelSEED cache with {len(self.df)} rows.")
         except FileNotFoundError:
             base_url = "https://raw.githubusercontent.com/ModelSEED/ModelSEEDDatabase/master/Biochemistry/compounds.tsv"
+            logging.info("ModelSEED cache not found. Downloading compounds.tsv...")
             result = requests.get(base_url)
             result.raise_for_status()
             with open(f"{self.data_path}/ModelSEED_compounds.tsv", "w") as f:
                 f.write(result.text)
-            self.df = pd.read_csv(f"{self.data_path}/ModelSEED_compounds.tsv", sep = "\t", dtype=object)
+            self.df = pd.read_csv(
+                f"{self.data_path}/ModelSEED_compounds.tsv", sep="\t", dtype=object
+            )
+            logging.info(
+                f"Downloaded and loaded ModelSEED cache with {len(self.df)} rows."
+            )
+        logging.info(f"[{time.perf_counter() - start:.3f} s] ModelSEED database ready.")
 
-            
     def get_assignments_by_id(self, meta_id):
         result = self.ModelSEED_dict.get(meta_id, None)
         if result is None:
@@ -45,43 +64,67 @@ class ModelSEEDInterface(DatabaseInterface):
     def search_identifier_seed(self, names, other_ids):
         """
         Function to search for an identifier in ModelSEED with the given name and references in other databases.
-        
+
         Args:
             names ([str]): List of known names of the metabolite.
-            other_ids ({db_id : [meta_ids]}): Dictionary mapping database identifiers to lists of known identifiers for the metabolite in that database. 
+            other_ids ({db_id : [meta_ids]}): Dictionary mapping database identifiers to lists of known identifiers for the metabolite in that database.
         """
-        other_ids = [meta_id.replace("META:", "") for meta_ids in other_ids.values() for meta_id in meta_ids["ids"]]
-        found_aliases = self.df["aliases"].dropna()[self.df["aliases"].dropna().apply(lambda aliases: any([(True if re.search(f"(:|;) {re.escape(x)}(\||;|\Z)", aliases) else False) for x in [*names, *other_ids]]))]
+        other_ids = [
+            meta_id.replace("META:", "")
+            for meta_ids in other_ids.values()
+            for meta_id in meta_ids["ids"]
+        ]
+        found_aliases = self.df["aliases"].dropna()[
+            self.df["aliases"]
+            .dropna()
+            .apply(
+                lambda aliases: any(
+                    [
+                        (
+                            True
+                            if re.search(rf"(:|;) {re.escape(x)}(\||;|\Z)", aliases)
+                            else False
+                        )
+                        for x in [*names, *other_ids]
+                    ]
+                )
+            )
+        ]
         found_ids = self.df["id"][found_aliases.index]
         return list(found_ids)
 
     def get_other_references(self, id, relevant_dbs):
-        id_mapping = {"BiGG" : "bigg.metabolite",
-                    "MetaCyc" : "biocyc"  
-                    }
+        id_mapping = {"BiGG": "bigg.metabolite", "MetaCyc": "biocyc"}
         references = {}
         if id.startswith("CPD"):
             id = id.replace("-", "")
         self.df["id"] = self.df["id"].str.lower()
         self.df["abbreviation"] = self.df["abbreviation"].str.lower()
         self.df["name"] = self.df["name"].str.lower()
-        found = self.df[(self.df["id"] == id.lower()) | (self.df["abbreviation"] == id.lower()) | (self.df["name"] == id.lower())]
+        found = self.df[
+            (self.df["id"] == id.lower())
+            | (self.df["abbreviation"] == id.lower())
+            | (self.df["name"] == id.lower())
+        ]
         if len(found) == 0 or found.empty:
             logging.debug(f"ModelSEED id: {id} could not be found in the database.")
             return references
         out_refs = found["aliases"].values[0]
-        if type(out_refs) != str: return references
-        else: 
+        if type(out_refs) != str:
+            return references
+        else:
             out_refs = out_refs.split("|")
+
         def split_into_identifiers(s):
             colon_index = s.find(":")
             if colon_index > -1:
                 db_identifier = s[:colon_index]
-                meta_id = s[colon_index + 2:]
-                if (db_identifier in id_mapping):
+                meta_id = s[colon_index + 2 :]
+                if db_identifier in id_mapping:
                     db_ref = references.get(db_identifier, set())
                     db_ref.update([mid.strip() for mid in meta_id.split(";")])
                     references[id_mapping[db_identifier]] = db_ref
+
         [split_into_identifiers(s) for s in out_refs]
-        
+
         return references

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ This also requires Microsoft Research's Z3 to run. You can download it from http
 
 In order to use this module, you need to install it first, e.g. by running `pip install .` in the folder you downloaded this repository to.
 
+If you want to preload and cache the external database artifacts before running curation, you can warm them up explicitly:
+```
+from MCC import MassChargeCuration
+
+MassChargeCuration.warm_up()
+```
+This warms the default cache directory. You can also pass `data_path`, `used_annotations`, `no_local`, or `biocyc_path` if you need to control which artifacts are prepared.
+
 To apply it to a model, simply load your model via cobrapy and instantiate a MassChargeCuration class with your model as parameter.
 If you are unsure about your models [identifiers.org](http://identifiers.org/) annotation, we also recommend to pass `update_ids = True` to the constructor. This will update any id used in the balancing effort, but will take longer (~15 minutes for 1200 Metabolites).
 ```


### PR DESCRIPTION
## Summary

This PR introduces an explicit warm-up workflow for external database resources and improves the visibility and startup performance of the default data interfaces.

The main changes are:

- add a new public `MassChargeCuration.warm_up(...)` entry point for preloading external database artifacts before running curation
- change the default cache location from `./data` to a stable user cache directory
- add clearer initialization and timing logs across the default database interfaces
- speed up MetaNetX startup by caching parsed tables and avoiding row-wise dataframe processing

## Motivation

External database initialization was hard to inspect and unnecessarily slow on cold start:

- there was no dedicated API for preloading caches before running curation
- interface setup gave little visibility into cache reuse, downloads, and per-database load time
- initializing `DataCollector` without a model produced a misleading warning even in the new warm-up path
- MetaNetX reparsed large TSV files on every fresh process, which dominated startup time

This PR adds a first-class warm-up path and makes startup behavior easier to understand and faster to repeat.

## What Changed

### New warm-up workflow

- add `MassChargeCuration.warm_up(...)` as a new public warm-up API
- add `DataCollector.warm_up(...)` to preload configured interfaces without constructing a model-backed collector
- configure INFO logging automatically for the new warm-up path when no logging handlers are present

### Cache path defaults

- introduce `default_data_path()`
- resolve the default cache directory via `XDG_CACHE_HOME` when available, otherwise `~/.cache/MassChargeCuration`
- use that default path in both `MassChargeCuration` and `DataCollector` when `data_path` is not provided

### Interface load visibility

- log cache directory creation or reuse
- log configured interfaces and whether local cache usage is enabled
- log per-interface load start, completion, and elapsed time
- warn when unknown annotations are requested and ignored
- suppress the misleading missing-model warning during intentional warm-up mode
- add cache hit/miss and download/consolidation logging in the default request interfaces

### MetaNetX startup optimization

- add persistent `.pkl` caches for `chem_xref.tsv`, `chem_depr.tsv`, and `chem_prop.tsv`
- reuse those caches when they are newer than the corresponding TSVs
- fall back to TSV parsing if cache loading fails or the cache is stale
- replace row-wise `apply`-based property-dict construction with vectorized `zip`-based construction
- add timing logs for MetaNetX table loading and property-map construction

### Documentation

- document the new `MassChargeCuration.warm_up()` API in the README
- describe supported parameters: `data_path`, `used_annotations`, `no_local`, and `biocyc_path`

## Expected Impact

- callers can preload external database artifacts explicitly before running curation
- startup progress is now visible instead of opaque
- repeated MetaNetX initialization is substantially faster once binary caches exist
- downloaded artifacts are stored in a stable cache directory rather than the current working tree by default

## Validation

- executed the new warm-up entry point repeatedly with `python -c "from MCC import MassChargeCuration; MassChargeCuration.warm_up()"`
- verified that the new warm-up path emits continuous INFO-level progress and timing logs
- verified that intentional warm-up no longer emits the spurious missing-model warning
- measured MetaNetX initialization in this environment:
  - before optimization: about 40 seconds for `metanetx.chemical`
  - after binary caches were populated: about 7 seconds for `metanetx.chemical`
- compared deterministic JSON snapshots of key MetaNetX lookup methods before and after the optimization and confirmed matching outputs for:
  - `get_assignments_by_id`
  - `get_other_references`
  - `update_id`
  - `search_identifier`
  - `update_ids`

## Notes

- this PR changes the default implicit cache location for callers that previously relied on `./data`
- no new external runtime dependency is introduced
